### PR TITLE
Omit hidden files in getImageEntries()

### DIFF
--- a/build/zip.js
+++ b/build/zip.js
@@ -66,7 +66,7 @@ exports.getImageEntries = function(zip) {
   }
   admZip = new AdmZip(zip);
   return _.chain(admZip.getEntries()).filter(function(entry) {
-    return _.includes(IMAGE_FORMATS, path.extname(entry.name));
+    return _.every([_.includes(IMAGE_FORMATS, path.extname(entry.name)), _.first(entry.name) !== '.']);
   }).map(function(entry) {
     return {
       name: entry.name,

--- a/lib/zip.coffee
+++ b/lib/zip.coffee
@@ -61,7 +61,10 @@ exports.getImageEntries = (zip) ->
 
 	return _.chain(admZip.getEntries())
 		.filter (entry) ->
-			return _.includes(IMAGE_FORMATS, path.extname(entry.name))
+			return _.every [
+				_.includes(IMAGE_FORMATS, path.extname(entry.name))
+				_.first(entry.name) isnt '.'
+			]
 		.map (entry) ->
 			return {
 				name: entry.name

--- a/tests/zip.spec.coffee
+++ b/tests/zip.spec.coffee
@@ -37,6 +37,17 @@ describe 'Resin Zip Image', ->
 			it 'should return an empty array', ->
 				m.chai.expect(zipImage.getImageEntries(@zip)).to.deep.equal([])
 
+		describe 'given a zip archive with image hidden files', ->
+
+			beforeEach ->
+				@zip = path.join(zips, 'hidden.zip')
+
+			it 'should ignore the hidden files', ->
+				m.chai.expect(zipImage.getImageEntries(@zip)).to.deep.equal [
+					name: 'raspberrypi.img'
+					size: 33554432
+				]
+
 		describe 'given a zip with a single image file', ->
 
 			beforeEach ->
@@ -96,6 +107,14 @@ describe 'Resin Zip Image', ->
 
 			it 'should return false', ->
 				m.chai.expect(zipImage.isValidZipImage(@zip)).to.be.false
+
+		describe 'given a zip archive with image hidden files', ->
+
+			beforeEach ->
+				@zip = path.join(zips, 'hidden.zip')
+
+			it 'should return true', ->
+				m.chai.expect(zipImage.isValidZipImage(@zip)).to.be.true
 
 		describe 'given a zip with a single image file', ->
 

--- a/tests/zip.spec.coffee
+++ b/tests/zip.spec.coffee
@@ -179,6 +179,8 @@ describe 'Resin Zip Image', ->
 				@image = path.join(zips, 'images', 'raspberrypi.img')
 
 			it 'should be able to extract the image', (done) ->
+				@timeout(10000)
+
 				output = tmp.tmpNameSync()
 
 				zipImage.extractImage(@zip).then (stream) ->


### PR DESCRIPTION
OS X creates copies of files prefixed with `._` as a backup purpose,
which makes `getImageEntries()` return multiple entries with an `img` or
`iso` extension, which results on this module treating the zip as an
invalid zip image.
